### PR TITLE
Исправления бага с пустым аудио

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -43,6 +43,13 @@ async def process_audio(websocket, audio_data):
         # Собираем текст (сегменты указывают не весь текст в аудио, а только в некотором промежутке времени. Для получения полной расщифровки их необходимо объединять)
         transcription = "".join([segment.text for segment in segments])
         
+        # Можно использовать для поиска и удаления определённых фраз. Так как STT прибавляет пробелы, то будет очень нужным
+        #print(f'Расшифровка. Длина {len(transcription)}. Текст:"{transcription}"')
+        
+        # " Продолжение следует..." и другие "приколы" от Fast Whisper при пустом аудио (без слов)
+        if transcription == " Продолжение следует..." or transcription == " Субтитры создавал DimaTorzok" or transcription == " Субтитры сделал DimaTorzok":
+            transcription = ""
+        
         # Отправляем обратно клиенту (поддерживается в сокетах по умолчанию)
         await websocket.send(transcription)
         print(f"Клиент получил расшифроку: {transcription}")


### PR DESCRIPTION
**Проблема:**
Видать у Fast Whisper были сделаны пасхалки, которые мешали корректной работе. При записи пустого аудио и отправки на сервер, мы получали не "", а " Продолжение следует..." и т.п. Данный код должен это исправить. Пока идёт поиск всех таких "пасхалок - приколов"

![Ветка1](https://github.com/user-attachments/assets/d062f143-a001-4911-8cc7-0465e8eedff7)


**Исправления:**
Все найденные фразы-пасхалки были добавлены в исключение. Теперь при отправке пустого аудио, пользователь не получит " Продолжение следует..."
![Ветка2](https://github.com/user-attachments/assets/3582be0e-d438-4ea4-845c-c41aee3b191e)


**Следующий шаг:**
В случае если пользователь будет молчать в промежутках фразы, данный баг может появится вновь, так как данное решение предназначено только для пустого аудио без слов. Поэтому, нужно будет проверять так же сегменты (у них отличаются фразы-пасхалки) на ту же проблему, но при этом не удаляя те фразы, которые действительно хотел сказать игрок